### PR TITLE
Enable CodeQL for Spatial Continuity and Spatial Continuity Camera

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,25 +29,24 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/periphery.yml@v2
     permissions:
       contents: read
-  # NOTE: CodeQL disabled until it supports the current Swift toolchain
-  # codeql_scc:
-  #   name: CodeQL Spatial Continuity Camera
-  #   uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-  #   with:
-  #     codeql: true
-  #     fastlanelane: ios codeql_scc
-  #   permissions:
-  #     security-events: write
-  #     actions: read
-  # codeql_sc:
-  #   name: CodeQL Spatial Continuity
-  #   uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-  #   with:
-  #     codeql: true
-  #     fastlanelane: visionos codeql_sc
-  #   permissions:
-  #     security-events: write
-  #     actions: read
+  codeql_sc:
+    name: CodeQL Spatial Continuity
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      codeql: true
+      fastlanelane: ios codeql_sc
+    permissions:
+      security-events: write
+      actions: read
+  codeql_scc:
+    name: CodeQL Spatial Continuity Camera
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      codeql: true
+      fastlanelane: ios codeql_scc
+    permissions:
+      security-events: write
+      actions: read
   buildandtest_scc:
     name: Build Spatial Continuity Camera (for Testing)
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
@@ -72,7 +71,7 @@ jobs:
       # We use the self-hosted runners as the main GitHub Action runners do not have the necessary performance.
       # Remove the `runsonlabels: '["macOS", "self-hosted"]'` lines if you do not administer your own GitHub Runners.
       runsonlabels: '["macOS", "self-hosted"]'
-      fastlanelane: visionos test_vision_pro # ${{ matrix.platform }}
+      fastlanelane: ios test_vision_pro # ${{ matrix.platform }}
       artifactname: ${{ matrix.platform }}.xcresult
   # NOTE: Disabled since no tests are being run ATM
   # uploadcoveragereport:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: MIT
 #
+default_platform(:ios)
+
 platform :ios do
   before_all do
     ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "5"
@@ -13,93 +15,13 @@ platform :ios do
 
   desc "Build and test"
   lane :test do
+		test_vision_pro
     test_iphone
   end
 
   desc "Build and test for iPhone"
   lane :test_iphone do
     private_test_scc(devices: ["iPhone 15 Pro"], result: "iphone")
-  end
-
-  desc "Internal build and test lane for Spatial Continuity Camera"
-  private_lane :private_test_scc do |options|
-    run_tests(
-			project: "SpatialContinuity.xcodeproj",
-			scheme: "SpatialContinuityCamera",
-      skip_build: true,
-      derived_data_path: ".derivedData",
-      xcargs: [
-        "-skipPackagePluginValidation",
-        "-skipMacroValidation"
-      ],
-      code_coverage: true,
-      devices: options[:devices],
-      force_quit_simulator: true,
-      reset_simulator: true,
-      prelaunch_simulator: false,
-      concurrent_workers: 1,
-      max_concurrent_simulators: 1,
-      destination: options[:destination],
-      result_bundle: true,
-      output_directory: ".",
-      result_bundle_path: "./#{options[:result]}.xcresult",
-			build_for_testing: true
-    )
-  end
-
-  desc "CodeQL Spatial Continuity Camera"
-  lane :codeql_scc do
-    build_app(
-			project: "SpatialContinuity.xcodeproj",
-			scheme: "SpatialContinuityCamera",
-      skip_archive: true,
-      skip_codesigning: true,
-      derived_data_path: ".derivedData",
-      xcargs: [
-        "-skipPackagePluginValidation",
-        "-skipMacroValidation"
-      ]
-    )
-  end
-
-  desc "Build app"
-  lane :build_scc do
-    build_app(
-			project: "SpatialContinuity.xcodeproj",
-			scheme: "SpatialContinuityCamera",
-      derived_data_path: ".derivedData",
-      xcargs: [
-        "-skipPackagePluginValidation",
-        "-skipMacroValidation"
-      ],
-      destination: "generic/platform=iOS",
-      output_directory: ".build",
-      archive_path: ".build/SpatialContinuityCamera.xcarchive",
-    )
-    # This is an unfortunate workaround for a bug in fastlane: https://github.com/fastlane/fastlane/pull/21319
-    Dir.chdir("..") do
-      sh(
-        "
-        xcodebuild \
-          -exportArchive \
-          -exportOptionsPlist ./fastlane/ExportOptions.plist \
-          -archivePath ./.build/SpatialContinuityCamera.xcarchive \
-          -exportPath ./.build
-        "
-      )
-    end
-  end
-end
-
-platform :visionos do
-  before_all do
-    ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "5"
-    ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "6"
-  end
-
-  desc "Build and test"
-  lane :test do
-		test_vision_pro
   end
 
   desc "Build and test for Vision Pro"
@@ -133,6 +55,33 @@ platform :visionos do
     )
   end
 
+
+  desc "Internal build and test lane for Spatial Continuity Camera"
+  private_lane :private_test_scc do |options|
+    run_tests(
+			project: "SpatialContinuity.xcodeproj",
+			scheme: "SpatialContinuityCamera",
+      skip_build: true,
+      derived_data_path: ".derivedData",
+      xcargs: [
+        "-skipPackagePluginValidation",
+        "-skipMacroValidation"
+      ],
+      code_coverage: true,
+      devices: options[:devices],
+      force_quit_simulator: true,
+      reset_simulator: true,
+      prelaunch_simulator: false,
+      concurrent_workers: 1,
+      max_concurrent_simulators: 1,
+      destination: options[:destination],
+      result_bundle: true,
+      output_directory: ".",
+      result_bundle_path: "./#{options[:result]}.xcresult",
+			build_for_testing: true
+    )
+  end
+
   desc "CodeQL Spatial Continuity"
   lane :codeql_sc do
     build_app(
@@ -141,6 +90,23 @@ platform :visionos do
       skip_archive: true,
       skip_codesigning: true,
       derived_data_path: ".derivedData",
+      destination: "generic/platform=visionOS",
+      xcargs: [
+        "-skipPackagePluginValidation",
+        "-skipMacroValidation"
+      ]
+    )
+  end
+
+  desc "CodeQL Spatial Continuity Camera"
+  lane :codeql_scc do
+    build_app(
+			project: "SpatialContinuity.xcodeproj",
+			scheme: "SpatialContinuityCamera",
+      skip_archive: true,
+      skip_codesigning: true,
+      derived_data_path: ".derivedData",
+      destination: "generic/platform=iOS",
       xcargs: [
         "-skipPackagePluginValidation",
         "-skipMacroValidation"
@@ -170,6 +136,34 @@ platform :visionos do
           -exportArchive \
           -exportOptionsPlist ./fastlane/ExportOptions.plist \
           -archivePath ./.build/SpatialContinuity.xcarchive \
+          -exportPath ./.build
+        "
+      )
+    end
+  end
+
+  desc "Build Spatial Continuity Camera"
+  lane :build_scc do
+    build_app(
+			project: "SpatialContinuity.xcodeproj",
+			scheme: "SpatialContinuityCamera",
+      derived_data_path: ".derivedData",
+      xcargs: [
+        "-skipPackagePluginValidation",
+        "-skipMacroValidation"
+      ],
+      destination: "generic/platform=iOS",
+      output_directory: ".build",
+      archive_path: ".build/SpatialContinuityCamera.xcarchive",
+    )
+    # This is an unfortunate workaround for a bug in fastlane: https://github.com/fastlane/fastlane/pull/21319
+    Dir.chdir("..") do
+      sh(
+        "
+        xcodebuild \
+          -exportArchive \
+          -exportOptionsPlist ./fastlane/ExportOptions.plist \
+          -archivePath ./.build/SpatialContinuityCamera.xcarchive \
           -exportPath ./.build
         "
       )


### PR DESCRIPTION
# Enable CodeQL for Spatial Continuity and Spatial Continuity Camera

## :recycle: Current situation & Problem
Since CodeQL now supports the latest Swift Toolchain, it can be enabled for the Spatial Continuity project.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
